### PR TITLE
Leverage pytest.mark to distinguish between unit tests (no mark), integration tests (integaration) and end to end tests (e2e)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,4 @@ jobs:
     - name: Run Tests
       uses: devcontainers/ci@v0.3
       with:
-        runCmd: python run_script.py pytest_all
+        runCmd: pytest -m  "not integration and not e2e"  # run unit tests only

--- a/README.md
+++ b/README.md
@@ -329,5 +329,5 @@ Unit tests are required in each PR, and Code Review process should ensure it. (L
   - Ensure data isolation to prevent tests from interfering with each other.
 * Naming: /e2e/<test-scenario>_e2e_test.py
 * Mark: `@pytest.mark.e2e`
-* Exceuted:
+* Execeuted:
   - Nightly on each environment: All tests are executed nightly (workflow will be added soon)

--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ This is a sample monorepo that can be used as a starting point for a python proj
 
 ### Next Steps
 The monorepo will be extendedt to support:
-1. Implement AppConfigConfigurationProvider based on AWS AppConfig and SSM - Start Lambda with AppConfigConfigurationProvider when runs on AWS + Define IAM role to access AppConfig and SSM
+1. Update AppConfigConfigurationProvider to use SSM ParameterStore instead of SecretsManager (cheapper, no need to auto-rotate keys at this point)
+2. When running in AWS mode,  Start Lambda with AppConfigConfigurationProvider when runs on AWS + Define IAM role to access AppConfig and SecretsManager
 2. Logging using [aws-powertools] (https://github.com/aws-powertools/powertools-lambda-python)
 3. Use Lambda Extensions to better handle calls to AppConfig and SSM
-4. Semantic release using [changeset](https://github.com/changesets/changesets) - blogpost [here](https://lirantal.com/blog/introducing-changesets-simplify-project-versioning-with-semantic-releases/
+4. Semantic release using [changeset](https://github.com/changesets/changesets) - blogpost [here](https://lirantal.com/blog/introducing-changesets-simplify-project-versioning-with-semantic-releases/)
 5. Terraform to deploy infra on localstack and on AWS
 6. Add a deployment.yml workflow to deploy to AWS and to Localstack
 7. Add e2e.yml workflow with a simple e2e test which runs nightly (every night)
@@ -296,3 +297,37 @@ curl https://8fwcdbjd95.execute-api.us-east-1.amazonaws.com/prod/hello/Danny
 ```
 
 **NOTE:** When deployed remotely, the greeting message returns with 5 exclamation points, according to the remote config, but when running locally or on local stack, it is returned with a single exclamation point. 
+
+## Testing
+
+Three main types of tests in this repo:
+**Unit Tests**
+* Tests individual software units (functions and classes) in isolation.
+* Best Practices: Write unit tests alongside code development, ensure comprehensive coverage of the unit's logic, and strive for isolated and repeatable tests.
+Unit tests are required in each PR, and Code Review process should ensure it. (Later on coverage tools will be added)
+* Naming: `<file-name>_test.py`
+* Mark: Given most of our tests are unit tests, there's no need to mark them
+* Executed: 
+  - Pre-push runs all impacted unit tests
+  - CI: All unit tests are executed automatically and must pass, otherwise merge to main fails
+  - Nightly: All tests are executed nightly (workflow will be added soon)
+
+**Integration Tests**
+* Verifies how different software units interact with each other.
+* Best Practices: Focus on interfaces and data exchange between units, test with stubs or mocks for external dependencies (except for the modules which their integration is being verified), and design tests to uncover integration issues.
+* Naming: `<file-name>_integration_test.py`
+* Mark: `@pytest.mark.integration`
+* Executed:
+  - Nightly on each environment: All tests are executed nightly (workflow will be added soon)
+
+**End-to-end Tests**
+* Simulates real user journeys, testing how different system components work together from start to finish. It encompasses functional, non-functional, and integration testing aspects.
+* Best Practices:
+  - Design tests that mimic real user workflows and critical business processes.
+  - Prioritize high-impact user scenarios that deliver the most value.
+  - Use realistic and well-structured test data sets that reflect real-world conditions.
+  - Ensure data isolation to prevent tests from interfering with each other.
+* Naming: /e2e/<test-scenario>_e2e_test.py
+* Mark: `@pytest.mark.e2e`
+* Exceuted:
+  - Nightly on each environment: All tests are executed nightly (workflow will be added soon)

--- a/packages/configuration/tests/app_config_configuration_provider_integration_test.py
+++ b/packages/configuration/tests/app_config_configuration_provider_integration_test.py
@@ -7,7 +7,7 @@ from configuration.configuration import Configuration
 from environment.environment_variables import EnvironmentVariables, reset_environment_variables
 
 
-class TestConfiguration(Configuration):
+class GooConfiguration(Configuration):
     def __init__(self, config_dict: ConfigurationSection):
         self.int1 = config_dict['int1']
         self.str2 = config_dict['str2']
@@ -16,7 +16,7 @@ class TestConfiguration(Configuration):
 
 @pytest.fixture
 def configuration():
-    return TestConfiguration({
+    return GooConfiguration({
         'int1': 1,
         'str2': '2',
         'secrets': {
@@ -28,7 +28,7 @@ def configuration():
 
 @pytest.fixture
 def configuration_with_populated_secrets():
-    return TestConfiguration({
+    return GooConfiguration({
         'int1': 1,
         'str2': '2',
         'secrets': {
@@ -77,7 +77,7 @@ def app_configuration_provider(env_variables):
     TODO (@limorl): Test can be imprived to deploy a newly created configuration and then deleted after test test
 """
 
-
+@pytest.mark.integration
 def test_init_and_get_configuration__success(
         app_configuration_provider,
         configuration,
@@ -86,7 +86,7 @@ def test_init_and_get_configuration__success(
 
     app_configuration_provider.init_configuration()
 
-    configuration: TestConfiguration = app_configuration_provider.get_configuration(TestConfiguration)
+    configuration: GooConfiguration = app_configuration_provider.get_configuration(GooConfiguration)
 
     # assert configuration is correct and secrets were populated
     assert configuration

--- a/packages/configuration/tests/app_config_configuration_provider_integration_test.py
+++ b/packages/configuration/tests/app_config_configuration_provider_integration_test.py
@@ -77,6 +77,7 @@ def app_configuration_provider(env_variables):
     TODO (@limorl): Test can be imprived to deploy a newly created configuration and then deleted after test test
 """
 
+
 @pytest.mark.integration
 def test_init_and_get_configuration__success(
         app_configuration_provider,

--- a/packages/configuration/tests/config/aws.dev.us-west-2.json
+++ b/packages/configuration/tests/config/aws.dev.us-west-2.json
@@ -1,5 +1,5 @@
 {
-    "TestConfiguration": {
+    "GooConfiguration": {
         "int1": 1,
         "str2": "2",
         "secrets": {

--- a/packages/scripts/scripts/testing/pytest_all.py
+++ b/packages/scripts/scripts/testing/pytest_all.py
@@ -1,4 +1,6 @@
+import argparse
 import os
+from pathlib import Path
 import pathspec
 import subprocess
 
@@ -29,17 +31,32 @@ def has_tests_folder(package_dir):
     return os.path.exists(os.path.join(package_dir, 'tests'))
 
 
-def run_pytest_for_package(package_dir):
+def run_pytest_for_package(package_dir: Path, type: str):
     if package_dir and has_tests_folder(package_dir):
-        subprocess.run(["pytest"], cwd=package_dir)
+        if type == "all":
+            subprocess.run(["pytest"], cwd=package_dir)
+        elif type == 'unit':
+            subprocess.run(["pytest", "-m", "not integration and not e2e"], cwd=package_dir)
+        else:
+            subprocess.run(["pytest", "-m", type], cwd=package_dir)
 
 
-def pytest_all():
+def pytest_all(mark: str):
     package_paths = get_package_paths()
     for path in package_paths:
         print("Running Pytest for package: ", path)
-        run_pytest_for_package(path)
+        run_pytest_for_package(path, mark)
+
+
+def _create_arg_parser():
+    parser = argparse.ArgumentParser(prog='pytest_all.py', description='Run all tests if given type using Pytest')
+    parser.add_argument('--type', type=str, required=False, default='all', help='The pytest mark to run [all|unit|integration|e2e]')
+    return parser
 
 
 if __name__ == "__main__":
-    pytest_all()
+    parser = _create_arg_parser()
+    args = parser.parse_args()
+
+    pytest_all(args.type)
+

--- a/packages/scripts/scripts/testing/pytest_all.py
+++ b/packages/scripts/scripts/testing/pytest_all.py
@@ -41,11 +41,11 @@ def run_pytest_for_package(package_dir: Path, type: str):
             subprocess.run(["pytest", "-m", type], cwd=package_dir)
 
 
-def pytest_all(mark: str):
+def pytest_all(type: str):
     package_paths = get_package_paths()
     for path in package_paths:
         print("Running Pytest for package: ", path)
-        run_pytest_for_package(path, mark)
+        run_pytest_for_package(path, type)
 
 
 def _create_arg_parser():
@@ -59,4 +59,3 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     pytest_all(args.type)
-

--- a/packages/scripts/scripts/testing/pytest_impacted_only.py
+++ b/packages/scripts/scripts/testing/pytest_impacted_only.py
@@ -49,16 +49,16 @@ def get_impacted_test_files(changed_files: List[str], package_paths: List[str]) 
     return impacted_test_files
 
 
-def run_pytest_on_files(dir: str, files) -> List[str]:
+def run_unit_tests_in_files(dir: str, files) -> List[str]:
     if files:
-        subprocess.run(['pytest', '-vs', ' '.join(files)], cwd=dir)
+        subprocess.run(['pytest', '-m', 'not integration and not e2e', '-vs', ' '.join(files)], cwd=dir)
 
 
 def _get_relative_path(full_path: str, relative_path: str) -> str:
     return os.path.relpath(full_path, relative_path)
 
 
-def pytest_impacted_only():
+def pytest_impacted_unit_tests():
     root_dir = os.getcwd()
     spec = load_gitignore(root_dir)
     package_paths = list(map(lambda x: _get_relative_path(str(x), root_dir), get_package_paths()))
@@ -69,8 +69,8 @@ def pytest_impacted_only():
 
     if impacted_test_files:
         print(f'Running {len(impacted_test_files)} impacted tests under {root_dir}')
-        run_pytest_on_files(root_dir, impacted_test_files)
+        run_unit_tests_in_files(root_dir, impacted_test_files)
 
 
 if __name__ == "__main__":
-    pytest_impacted_only()
+    pytest_impacted_unit_tests()


### PR DESCRIPTION
* Added pytest mark integration to mar app configuration provider integration tests
* Update ci workflow to run unit tests: all test not marked as integration nor e2e
* Updated pytest_all script to accept --type. This script is no longer needed but since pytest discovery is sometime too sensitive to minor erors, it can be used to run tests until fixed.